### PR TITLE
Userdefined form Updates

### DIFF
--- a/src/Forms/EditableHoneypotField.php
+++ b/src/Forms/EditableHoneypotField.php
@@ -7,6 +7,7 @@ use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\UserForms\Model\EditableFormField;
 use SilverStripe\ORM\UnsavedRelationList;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Injector\Injector;
 
 class EditableHoneypotField extends EditableFormField

--- a/src/Forms/EditableHoneypotField.php
+++ b/src/Forms/EditableHoneypotField.php
@@ -7,6 +7,7 @@ use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\UserForms\Model\EditableFormField;
 use SilverStripe\ORM\UnsavedRelationList;
+use SilverStripe\Core\Injector\Injector;
 
 class EditableHoneypotField extends EditableFormField
 {

--- a/src/Forms/EditableHoneypotField.php
+++ b/src/Forms/EditableHoneypotField.php
@@ -21,11 +21,15 @@ class EditableHoneypotField extends EditableFormField
    /**/
     public function getFormField()
     {
+      // Clear Any existing errors
+      $Request = Injector::inst()->get(HTTPRequest::class);
+      $Session = $Request->getSession();
+      $Session->clear('spam-protection-error-exists');
      //
-        $field = HoneypotField::create($this->Name, "", null)->setFieldHolderTemplate('Form\\SpamFieldHolder');
-        $this->doUpdateFormField($field);
+      $field = HoneypotField::create($this->Name, "", null)->setFieldHolderTemplate('Form\\SpamFieldHolder');
+      $this->doUpdateFormField($field);
      //
-        return $field;
+      return $field;
     }
   /**
    * @param FormField $field
@@ -69,6 +73,12 @@ class EditableHoneypotField extends EditableFormField
    */
     protected function updateFormField($field)
     {
-        parent::updateFormField($field);
+      // Add custom error
+      if ($this->CustomErrorMessage <> ""){
+        $field->setAttribute('data-custommsg', (string) $this->CustomErrorMessage);
+      }
+      //
+      parent::updateFormField($field);
     }
+
 }

--- a/src/Forms/EditableTimerField.php
+++ b/src/Forms/EditableTimerField.php
@@ -4,9 +4,10 @@ namespace Werkbot\SpamProtection;
 
 use Werkbot\SpamProtection\TimerField;
 use SilverStripe\Forms\FormField;
-use SilverStripe\Forms\TextField;
+use SilverStripe\Forms\NumericField;
 use SilverStripe\UserForms\Model\EditableFormField;
 use SilverStripe\ORM\UnsavedRelationList;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Injector\Injector;
 
 class EditableTimerField extends EditableFormField

--- a/src/Forms/EditableTimerField.php
+++ b/src/Forms/EditableTimerField.php
@@ -7,6 +7,7 @@ use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\UserForms\Model\EditableFormField;
 use SilverStripe\ORM\UnsavedRelationList;
+use SilverStripe\Core\Injector\Injector;
 
 class EditableTimerField extends EditableFormField
 {

--- a/src/Forms/HoneypotField.php
+++ b/src/Forms/HoneypotField.php
@@ -29,16 +29,34 @@ class HoneypotField extends TextField
         $ID = substr($StringID[0], strrpos($StringID[0], '_') + 1);
         $ID = rtrim($ID, '"');
       //
+        $Attributes = $this->getAttributes();
+        $Request = Injector::inst()->get(HTTPRequest::class);
+        $Session = $Request->getSession();
+      //
         if (!empty($this->Value())) {
-          // Not expecting any value
-            $validator->validationError(
+          if (!$Session->get('spam-protection-error-exists')) {
+            $Session->set('spam-protection-error-exists', true);
+            // Add custom error message
+            if(isset($Attributes['data-custommsg']) && $Attributes['data-custommsg'] <> ""){
+              $validator->validationError(
                 $this->Name,
-                _t('Werkbot\SpamProtection\Honeypot.INVALID', 'There was an error submitting this form. Please try again.')
-            );
-            if (intval($ID !== 0)) {
-                  $form->sessionMessage(_t('Werkbot\SpamProtection\Honeypot.INVALID', 'There was an error submitting this form. Please try again.'), 'bad');
+                $Attributes['data-custommsg']
+              );
+              if (intval($ID !== 0)) {
+                $form->sessionMessage($Attributes['data-custommsg'], 'bad');
+              }
+            } else {
+              // Not expecting any value
+              $validator->validationError(
+                  $this->Name,
+                  _t('Werkbot\SpamProtection\Honeypot.INVALID', 'There was an error submitting this form. Please try again.')
+              );
+              if (intval($ID !== 0)) {
+                $form->sessionMessage(_t('Werkbot\SpamProtection\Honeypot.INVALID', 'There was an error submitting this form. Please try again.'), 'bad');
+              }
             }
-            return false;
+          }
+          return false;
         }
       //
         return true;

--- a/src/Forms/TimerField.php
+++ b/src/Forms/TimerField.php
@@ -3,6 +3,7 @@
 namespace Werkbot\SpamProtection;
 
 use SilverStripe\Forms\TextField;
+use SilverStripe\Core\Injector\Injector;
 
 class TimerField extends TextField
 {

--- a/src/Forms/TimerField.php
+++ b/src/Forms/TimerField.php
@@ -3,6 +3,7 @@
 namespace Werkbot\SpamProtection;
 
 use SilverStripe\Forms\TextField;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Injector\Injector;
 
 class TimerField extends TextField

--- a/src/Forms/TimerField.php
+++ b/src/Forms/TimerField.php
@@ -22,17 +22,31 @@ class TimerField extends TextField
   /**/
     public function validate($validator)
     {
+      $Attributes = $this->getAttributes();
+      $Request = Injector::inst()->get(HTTPRequest::class);
+      $Session = $Request->getSession();
       //
-        $Timer = (($this->config()->time_not_bot) ? $this->config()->time_not_bot : $this->time_not_bot);
+        $Timer = ((isset($Attributes['data-rule-customtime'])) ? $Attributes['data-rule-customtime'] : (($this->config()->time_not_bot) ? $this->config()->time_not_bot : $this->time_not_bot));
         $CurrentTime = time();
       // Compare time difference with allowed time difference
-        if (empty($this->Value()) || !is_numeric($this->Value()) || (($CurrentTime - $this->Value()) < $Timer)) {
-          // Not the expected value, set error
-            $validator->validationError(
+        if ((empty($this->Value()) || !is_numeric($this->Value()) || (($CurrentTime - $this->Value()) < $Timer))) {
+          if (!$Session->get('spam-protection-error-exists')) {
+            // Set Session
+            $Session->set('spam-protection-error-exists', true);
+            //
+            if(isset($Attributes['data-custommsg']) && $Attributes['data-custommsg'] <> ""){
+              $validator->validationError(
+                $this->Name,
+                $Attributes['data-custommsg']
+              );
+            } else {
+              $validator->validationError(
                 $this->Name,
                 _t('Werkbot\SpamProtection\Timer.INVALID', 'There was an error submitting this form. Please try again.')
-            );
-            return false;
+              );
+            }
+          }
+          return false;
         }
       //
         return true;


### PR DESCRIPTION
- Added timer to be configurable inside silverstripe admin
- Updated error messages to only show 1 time even if both field types are added
- Update to allow for the custom error messages to display

### Summary
> Updated for userdefined form issues https://werkbotstudios.teamwork.com/#/tasks/29058693

### Testing Steps
- [x] run dev/build
- [x] Add both field types and test with custom error messages
- [x] Verify only one message shows
- [ ] Test timer min time set in the admin and that this works as expected
