### PR TITLE
Feature/workflow files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,3 +10,8 @@
 ### Issues/Concerns
 - A concern or issue
 - A second concern or issue
+
+### Git Flow
+- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
+- "Squash and merge" is good on "feature/\*" into "develop"
+- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,8 +3,10 @@ tag-template: '$RESOLVED_VERSION'
 categories:
   - title: '🚀 Features'
     labels:
+      - 'feat'
       - 'feature'
       - 'enhancement'
+      - 'improvements'
   - title: '🐛 Bug Fixes'
     labels:
       - 'fix'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/.github/tag-changelog-config.js
+++ b/.github/tag-changelog-config.js
@@ -1,0 +1,32 @@
+module.exports = {
+  types: [
+    { types: ["feat", "feature"], label: "🎉 New Features" },
+    { types: ["fix", "bugfix", "bug"], label: "🐛 Bugfixes" },
+    { types: ["improvements", "enhancement"], label: "🔨 Improvements" },
+    { types: ["perf"], label: "🏎️ Performance Improvements" },
+    { types: ["build", "ci"], label: "🏗️ Build System" },
+    { types: ["refactor"], label: "🪚 Refactors" },
+    { types: ["doc", "docs"], label: "📚 Documentation Changes" },
+    { types: ["test", "tests"], label: "🔍 Tests" },
+    { types: ["style"], label: "💅 Code Style Changes" },
+    { types: ["chore"], label: "🧹 Chores" },
+    { types: ["other"], label: "Other Changes" },
+  ],
+
+  excludeTypes: ["other"],
+
+  renderTypeSection: function (label, commits) {
+    let text = `\n## ${label}\n`;
+
+    commits.forEach((commit) => {
+      text += `- ${commit.subject}\n`;
+    });
+
+    return text;
+  },
+
+  renderChangelog: function (release, changes) {
+    const now = new Date();
+    return `## ${release} - ${now.toISOString().substr(0, 10)}\n` + changes + "\n\n";
+  },
+};

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,33 @@
+name: Generate Changelog
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update_changelog:
+    runs-on: ubuntu-latest
+    outputs:
+      output: ${{ steps.changelog.outputs.changelog }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: main
+      - name: Generate Changelog
+        id: changelog
+        uses: loopwerk/tag-changelog@v1.0.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          exclude_types: other,doc,chore
+          config_file: .github/tag-changelog-config.js
+      - name: Output Changelog
+        id: output_changelog
+        run: TAGCONTENT="${{ steps.changelog.outputs.changelog }}";CHANGELOG=$(cat CHANGELOG.md);CHANGELOG=$(echo "$CHANGELOG" | sed -e "s/# Changelog//");echo -e "# Changelog\n\n$TAGCONTENT$CHANGELOG" > CHANGELOG.md
+      - name: Commit Updated Changelog
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Updated CHANGELOG.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: main
+
       - name: Generate Changelog
         id: changelog
         uses: loopwerk/tag-changelog@v1.0.4
@@ -24,9 +25,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           exclude_types: other,doc,chore
           config_file: .github/tag-changelog-config.js
+
       - name: Output Changelog
         id: output_changelog
         run: TAGCONTENT="${{ steps.changelog.outputs.changelog }}";CHANGELOG=$(cat CHANGELOG.md);CHANGELOG=$(echo "$CHANGELOG" | sed -e "s/# Changelog//");echo -e "# Changelog\n\n$TAGCONTENT$CHANGELOG" > CHANGELOG.md
+
       - name: Commit Updated Changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/draftrelease.yml
+++ b/.github/workflows/draftrelease.yml
@@ -3,7 +3,8 @@ name: Release Drafter
 on:
   push:
     branches:
-      - main
+      - release/*
+      - hotfix/*
 
 permissions:
   contents: read
@@ -13,14 +14,70 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    outputs:
-      output: ${{ steps.update_release_draft.outputs.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@master
         with:
           fetch-depth: 0
 
+      # NEW RELEASES
+      # Check if this is a release branch
+      - name: Check For release branch
+        id: is_release_branch
+        continue-on-error: true
+        run: |
+          FILTEREDBRANCHNAME=$(git branch | grep "\* release")
+          echo "::set-output name=filtered_branch_name::$FILTEREDBRANCHNAME"
+
+      # Get the release tag
+      - name: Get release Tag
+        id: get_release_tag
+        if: steps.is_release_branch.outputs.filtered_branch_name != ''
+        run: |
+          RELEASETAG=$(git branch | grep \* | sed -re "s/release\///;s/\*//;s/\s*//g")
+          echo "::set-output name=release_tag::$RELEASETAG"
+
+      # Draft Release with release branch
+      - name: Draft Release with release branch
+        id: update_release_draft_with_release_branch
+        if: steps.is_release_branch.outputs.filtered_branch_name != ''
+        uses: tiller1010/release-drafter@master
+        with:
+          tag: ${{ steps.get_release_tag.outputs.release_tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+      # SUPPORT HOTFIXES
+      # Check if this is a hotfix branch
+      - name: Check For hotfix branch
+        id: is_hotfix_branch
+        if: steps.is_release_branch.outputs.filtered_branch_name == ''
+        continue-on-error: true
+        run: |
+          FILTEREDBRANCHNAME=$(git branch | grep "\* hotfix")
+          echo "::set-output name=filtered_branch_name::$FILTEREDBRANCHNAME"
+
+      # Get the hotfix tag
+      - name: Get hotfix Tag
+        id: get_hotfix_tag
+        if: steps.is_hotfix_branch.outputs.filtered_branch_name != ''
+        run: |
+          RELEASETAG=$(git branch | grep \* | sed -re "s/hotfix\///;s/\*//;s/\s*//g")
+          echo "::set-output name=release_tag::$RELEASETAG"
+
+      # Draft Release with hotfix branch
+      - name: Draft Release with hotfix branch
+        id: update_release_draft_with_hotfix_branch
+        if: steps.is_hotfix_branch.outputs.filtered_branch_name != ''
+        uses: tiller1010/release-drafter@master
+        with:
+          tag: ${{ steps.get_hotfix_tag.outputs.release_tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+      # RELEASE BRANCHING (NOT GIT-FLOW)
       # Get the last tag created on this branch
       - name: Get Last Tag
         id: last_tag
@@ -28,8 +85,10 @@ jobs:
           LASTTAG=$(git describe --tags | sed -re "s/-.+//")
           echo "::set-output name=last_tag_on_branch::$LASTTAG"
 
-      - name: Draft Release
+      # Draft Release with Previous Tag
+      - name: Draft Release with Previous Tag
         id: update_release_draft
+        if: steps.is_release_branch.outputs.filtered_branch_name == '' && steps.is_hotfix_branch.outputs.filtered_branch_name == ''
         uses: tiller1010/release-drafter@master
         with:
           last_tag: ${{ steps.last_tag.outputs.last_tag_on_branch }}

--- a/.github/workflows/draftrelease.yml
+++ b/.github/workflows/draftrelease.yml
@@ -1,0 +1,37 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    outputs:
+      output: ${{ steps.update_release_draft.outputs.tag_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      # Get the last tag created on this branch
+      - name: Get Last Tag
+        id: last_tag
+        run: |
+          LASTTAG=$(git describe --tags | sed -re "s/-.+//")
+          echo "::set-output name=last_tag_on_branch::$LASTTAG"
+
+      - name: Draft Release
+        id: update_release_draft
+        uses: tiller1010/release-drafter@master
+        with:
+          last_tag: ${{ steps.last_tag.outputs.last_tag_on_branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_release_draft.yml
+++ b/.github/workflows/publish_release_draft.yml
@@ -1,0 +1,71 @@
+name: Publish draft release when release branch is merged
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+      - support/*
+
+jobs:
+  publish_release:
+    if: ${{ github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get release id
+        id: get_release_id
+        run: |
+          TOKEN=${{ secrets.GITHUB_TOKEN }}
+          RELEASEID=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: token $TOKEN" https://api.github.com/repos/werkbot/silverstripe-spam-module/releases)
+          RELEASEID=$(echo "$RELEASEID" | grep \"id\"  | head -n 1 | sed -re "s/[a-z]*//g;s/[-|,|:|'\"]//g;s/\s//g")
+          echo "::set-output name=release_id::$RELEASEID"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish release
+        uses: eregon/publish-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_id: ${{ steps.get_release_id.outputs.release_id }}
+
+      - name: Payload info
+        id: payload_info
+        uses: Dovyski/payload-info-action@master
+        continue-on-error: true
+
+      # Generate changelog, changelog.yml is not triggered by other actions
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.payload_info.outputs.pull_request.base.ref }}
+
+      # Check if this is a support branch
+      - name: Check For support branch
+        id: is_support_branch
+        continue-on-error: true
+        run: |
+          FILTEREDBRANCHNAME=$(git branch | grep "\* support")
+          echo "::set-output name=filtered_branch_name::$FILTEREDBRANCHNAME"
+
+      - name: Generate Changelog
+        id: changelog
+        if: steps.is_support_branch.outputs.filtered_branch_name == ''
+        uses: loopwerk/tag-changelog@v1.0.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          exclude_types: other,doc,chore
+          config_file: .github/tag-changelog-config.js
+
+      - name: Output Changelog
+        id: output_changelog
+        if: steps.is_support_branch.outputs.filtered_branch_name == ''
+        run: TAGCONTENT="${{ steps.changelog.outputs.changelog }}";CHANGELOG=$(cat CHANGELOG.md);CHANGELOG=$(echo "$CHANGELOG" | sed -e "s/# Changelog//");echo -e "# Changelog\n\n$TAGCONTENT$CHANGELOG" > CHANGELOG.md
+
+      - name: Commit Updated Changelog
+        if: steps.is_support_branch.outputs.filtered_branch_name == ''
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Updated CHANGELOG.md
+          branch: ${{ steps.payload_info.outputs.pull_request.base.ref }}

--- a/.github/workflows/publish_release_draft.yml
+++ b/.github/workflows/publish_release_draft.yml
@@ -69,3 +69,10 @@ jobs:
         with:
           commit_message: Updated CHANGELOG.md
           branch: ${{ steps.payload_info.outputs.pull_request.base.ref }}
+
+      # Remove the release or hotfix branch after publishing
+      - name: Remove PR branch
+        uses: dawidd6/action-delete-branch@v3
+        with:
+          github_token: ${{github.token}}
+          branches: ${{ steps.payload_info.outputs.branch }}

--- a/.github/workflows/pull_request_labels.yml
+++ b/.github/workflows/pull_request_labels.yml
@@ -1,0 +1,15 @@
+name: Pull Request Labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          mode: exactly
+          count: 1
+          labels: "patch, minor, major"

--- a/.github/workflows/sync_develop_with_main.yml
+++ b/.github/workflows/sync_develop_with_main.yml
@@ -1,0 +1,52 @@
+name: Sync develop branch with main
+
+on:
+  push:
+    branches:
+      - main
+      - support/*
+
+permissions:
+  contents: write
+
+jobs:
+  sync_develop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      # Check if this is a support branch
+      - name: Check For support branch
+        id: is_support_branch
+        continue-on-error: true
+        run: |
+          FILTEREDBRANCHNAME=$(git branch | grep "\* support")
+          echo "::set-output name=filtered_branch_name::$FILTEREDBRANCHNAME"
+
+      # Get the support branch
+      - name: Get support branch
+        id: get_support_branch
+        if: steps.is_support_branch.outputs.filtered_branch_name != ''
+        run: |
+          SUPPORTBRANCH=$(git branch | grep \* | sed -re "s/[\*|\ ]//g")
+          echo "::set-output name=support_branch::$SUPPORTBRANCH"
+
+      - name: Merge support -> main
+        uses: devmasx/merge-branch@master
+        if: steps.is_support_branch.outputs.filtered_branch_name != ''
+        with:
+          type: now
+          from_branch: ${{ steps.get_support_branch.outputs.support_branch }}
+          target_branch: main
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          message: Merged ${{ steps.get_support_branch.outputs.support_branch }} into main
+
+      - name: Merge main -> develop
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          from_branch: main
+          target_branch: develop
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          message: Merged main into develop

--- a/delete-stale-release-branches.sh
+++ b/delete-stale-release-branches.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Delete any local release or hotfix branches
+#
+# Run with:
+# sh delete-stale-release-branches.sh
+
+for branch in $(git for-each-ref --format='%(refname)' refs/heads/)
+do
+    if echo $branch | grep hotfix &> /dev/null || echo $branch | grep release &> /dev/null;
+    then
+      BRANCHNAME=$(echo $branch | sed -re "s/refs\/heads\///")
+      git branch -D $BRANCHNAME
+    fi
+done

--- a/sync-branches-with-remote.sh
+++ b/sync-branches-with-remote.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Sync main and develop with remote
+#
+# Run with:
+# sh sync-branches-with-remote.sh
+
+git checkout main
+git pull
+git checkout develop
+git pull


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/#/tasks/29567255

### Summary
- Added workflow flows from recent repos
- Added workflow files that behave like git flow finish commands
   - **publish_release_draft.yml**: publishes the draft release when "release/\*" is merged into "main", also publishes patches when a "hotfix/\*" branch is merged into a "support/\*" branch
   - **sync_develop_with_main.yml**: merges "main" into "develop" when main receives commits (merged PRs), also merges "support/\*" into "main" and main into "develop" when "support/\*" receives commits (merged PRs)

### Testing Steps
- [x] start a fork
- [x] confirm actions are enabled on your fork
- [x] merge this pr into your fork's "develop" branch
- [x] see my comment below and update your workflow file on "develop"
#### New release testing
- [x] from your develop branch, start a release: `git flow release start 1.1.0` **or** `git checkout -b release/1.1.0`
- [x] commit to your release branch if you like (release notes, comments, etc)
- [x] start a PR for your release branch into "main", use the appropriate semvar label ("minor" in the case of 1.1.0)
- [x] confirm this drafted a release
- [x] merge the PR with a merge commit, **DO NOT** delete the branch just yet. View the "Actions" tab, there should be a "publish" action running. You can delete your branch after this is finished
- [x] confirm the release was published
- [x] confirm "main" was automatically merged into "develop"
#### Support patch testing
- [x] start a support branch: `git flow support start 1.0.x 1.0.3` **or** `git checkout 1.0.3;git checkout -b support/1.0.x` (your last "1.0.x" tag may vary)
- [x] push this support branch up: `git push -u origin support/1.0.x`
- [x] start a hotfix branch off of your support branch: `git flow hotfix start 1.0.4 support/1.0.x` **or** `git checkout support/1.0.x;git checkout -b hotfix/1.0.4`
- [x] commit to your hotfix branch if you like (release notes, comments, etc)
- [x] start a PR for your hotfix branch into your support branch, use the appropriate semvar label ("patch" in the case of 1.0.4)
- [x] confirm this drafted a release
- [x] merge the PR with a merge commit, **DO NOT** delete the branch just yet. View the "Actions" tab, there should be a "publish" action running. You can delete your branch after this is finished
- [x] confirm the release was published (scroll down, as it is sorted lower)
- [x] confirm "support/1.0.x" was automatically merged into "main" and "main" was automatically merged into "develop"

### Issues/Concerns
- Git flow commands do not work so well if you have existing "hotfix/" or "release/" branches locally. These are not deleted automatically when things happen on github. I had to run `git branch -D ...` or `git flow release delete -f ...` a few times for the flow commands to work. Luckily, using these is not required, and flow branches can still be created normally.
- The publish action requires the PR branch to remain up until the action finishes. We may need to add a warning in the PR description for this (or any other git flow tips that could help now that I think about it).
- My test PRs for reference. It might be helpful to hover over these to see which branches went where:
https://github.com/tiller1010/silverstripe-spam-module/pulls?q=is%3Apr+is%3Aclosed