### PR TITLE
Update publish workflow to multi-job version

### DIFF
--- a/.github/workflows/publish_release_draft.yml
+++ b/.github/workflows/publish_release_draft.yml
@@ -9,11 +9,14 @@ on:
       - support/*
 
 jobs:
-  publish_release:
-    if: ${{ github.event.pull_request.merged }}
+  pre_release_setup:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged }}
+    outputs:
+      release_id: ${{ steps.get_release_id.outputs.release_id }}
+      pr_branch: ${{ steps.payload_info.outputs.branch }}
+      support_branch_name: ${{ steps.is_support_branch.outputs.support_branch_name }}
     steps:
-
       - name: Checkout
         uses: actions/checkout@master
         with:
@@ -41,66 +44,68 @@ jobs:
         uses: tiller1010/payload-info-action@master
         continue-on-error: true
 
-
-      # START HOTFIX RELEASE RE-DRAFT
-      - name: Check if releasing a hotfix
-        id: is_hotfix_branch
-        continue-on-error: true
-        run: |
-          PRBRANCH="${{ steps.payload_info.outputs.branch }}"
-          FILTEREDBRANCHNAME=$(echo "$PRBRANCH" | grep "hotfix")
-          echo "filtered_pr_branch_name=$FILTEREDBRANCHNAME" >> $GITHUB_OUTPUT
-
-      - name: Get hotfix Tag from branch name
-        id: get_hotfix_tag
-        if: steps.is_hotfix_branch.outputs.filtered_pr_branch_name != ''
-        run: |
-          HOTFIXBRANCH="${{ steps.payload_info.outputs.branch }}"
-          RELEASETAG=$(echo "$HOTFIXBRANCH" | sed -re "s/(\* )?hotfix\///;s/(\w+)\/.*/\1/g")
-          echo "release_tag=$RELEASETAG" >> $GITHUB_OUTPUT
-
-      - name: Get Last Tag created on this branch
-        id: last_tag
-        if: steps.is_hotfix_branch.outputs.filtered_pr_branch_name != ''
-        run: |
-          LASTTAG=$(git describe --tags | sed -re "s/-.+//")
-          echo "last_tag_on_branch=$LASTTAG" >> $GITHUB_OUTPUT
-
-      # Re-Draft Release with hotfix tag
-      # "release-drafter" works by checking the changes of merged pull requests.
-      # For support or main branch hotfixes, there is only one merged hotfix PR, which is only now available,
-      # so we need to re-draft the release with the recently merged PR for release notes.
-      - name: Draft Release with hotfix tag
-        id: update_release_draft_with_hotfix_branch
-        if: steps.is_hotfix_branch.outputs.filtered_pr_branch_name != ''
-        uses: tiller1010/release-drafter@master
-        with:
-          tag: ${{ steps.get_hotfix_tag.outputs.release_tag }}
-          last_tag: ${{ steps.last_tag.outputs.last_tag_on_branch }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # END HOTFIX RELEASE RE-DRAFT
-
-
-      - name: Publish release
-        uses: eregon/publish-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          release_id: ${{ steps.get_release_id.outputs.release_id }}
-
-
-      # START CHANGELOG PORTION
       - name: Check if releasing for a support branch
         id: is_support_branch
         continue-on-error: true
         run: |
           FILTEREDBRANCHNAME=$(git branch | grep "\* support")
-          echo "filtered_branch_name=$FILTEREDBRANCHNAME" >> $GITHUB_OUTPUT
+          echo "support_branch_name=$FILTEREDBRANCHNAME" >> $GITHUB_OUTPUT
+
+
+  pre_release_redraft:
+    runs-on: ubuntu-latest
+    needs: pre_release_setup
+    steps:
+      - name: Get release/hotfix Tag from branch name
+        id: get_release_or_hotfix_tag
+        run: |
+          BRANCH="${{ needs.pre_release_setup.outputs.pr_branch }}"
+          RELEASETAG=$(echo "$BRANCH" | sed -re "s!(\* )?(release|hotfix)/!!;s!(\w+)/.*!\1!g")
+          echo "release_tag=$RELEASETAG" >> $GITHUB_OUTPUT
+
+      - name: Get Last Tag created on this branch
+        id: last_tag
+        run: |
+          LASTTAG=$(git describe --tags | sed -re "s/-.+//")
+          echo "last_tag_on_branch=$LASTTAG" >> $GITHUB_OUTPUT
+
+      # Re-Draft Release with release/hotfix tag
+      # "release-drafter" works by checking the changes of merged pull requests.
+      # For support or main branch hotfixes, there is only one merged release/hotfix PR, which is only now available.
+      # There might also be new commits added to a release PR
+      # We need to re-draft the release with the recently merged PR for release notes.
+      - name: Draft Release with release/hotfix tag
+        id: update_release_draft_with_hotfix_branch
+        uses: tiller1010/release-drafter@master
+        with:
+          tag: ${{ steps.get_release_or_hotfix_tag.outputs.release_tag }}
+          last_tag: ${{ steps.last_tag.outputs.last_tag_on_branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+  publish_release:
+    runs-on: ubuntu-latest
+    needs: [pre_release_setup, pre_release_redraft]
+    steps:
+      - name: Publish release
+        uses: eregon/publish-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_id: ${{ needs.pre_release_setup.outputs.release_id }}
+
+
+  generate_changelog:
+    runs-on: ubuntu-latest
+    needs: [pre_release_setup, publish_release]
+    if: needs.pre_release_setup.outputs.support_branch_name == ''
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
 
       - name: Generate Changelog
         id: changelog
-        if: steps.is_support_branch.outputs.filtered_branch_name == ''
         uses: tiller1010/tag-changelog@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -109,20 +114,17 @@ jobs:
 
       - name: Output Changelog
         id: output_changelog
-        if: steps.is_support_branch.outputs.filtered_branch_name == ''
         run: TAGCONTENT="${{ steps.changelog.outputs.changelog }}";CHANGELOG=$(cat CHANGELOG.md);CHANGELOG=$(echo "$CHANGELOG" | sed -e "s/# Changelog//");echo -e "# Changelog\n\n$TAGCONTENT$CHANGELOG" > CHANGELOG.md
 
       - name: Create Pull Request
         id: create_pr
-        if: steps.is_support_branch.outputs.filtered_branch_name == ''
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v7
         with:
           title: Auto-Update CHANGELOG.md
           commit-message: Updated CHANGELOG.md
           labels: automerge
 
       - name: Approve PR
-        if: steps.is_support_branch.outputs.filtered_branch_name == ''
         uses: hmarr/auto-approve-action@v3
         with:
           review-message: Auto approved automated PR
@@ -130,24 +132,21 @@ jobs:
           github-token: ${{ secrets.SOME_USERS_PAT }}
 
       - name: Auto merge
-        if: steps.is_support_branch.outputs.filtered_branch_name == ''
         uses: pascalgn/automerge-action@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST: ${{ steps.create_pr.outputs.pull-request-number }}
           MERGE_DELETE_BRANCH: true
 
-      - name: Post Changelog Checkout
-        if: steps.is_support_branch.outputs.filtered_branch_name == ''
-        uses: actions/checkout@master
-        with:
-          ref: main
-      # END CHANGELOG PORTION
 
-
+  merge_into_develop:
+    runs-on: ubuntu-latest
+    needs: [pre_release_setup, generate_changelog]
+    if: ${{ always() }}
+    steps:
       # Merge support changes into develop so they can be included in the next release
       - name: Merge support -> develop
-        if: steps.is_support_branch.outputs.filtered_branch_name != ''
+        if: needs.pre_release_setup.support_branch_name != ''
         uses: devmasx/merge-branch@master
         with:
           type: now
@@ -157,7 +156,7 @@ jobs:
 
       # Merge main changes into develop
       - name: Merge main -> develop
-        if: steps.is_support_branch.outputs.filtered_branch_name == ''
+        if: needs.pre_release_setup.support_branch_name == ''
         uses: devmasx/merge-branch@master
         with:
           type: now
@@ -171,4 +170,4 @@ jobs:
         uses: dawidd6/action-delete-branch@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branches: ${{ steps.payload_info.outputs.branch }}
+          branches: ${{ needs.pre_release_setup.outputs.pr_branch }}


### PR DESCRIPTION
### Summary
> Update publish workflow to multi-job version

### Testing Steps
- [ ] Runs as expected

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
